### PR TITLE
Return compiled path as string

### DIFF
--- a/coremlprofiler/prof.py
+++ b/coremlprofiler/prof.py
@@ -81,7 +81,7 @@ class CoreMLProfiler:
             raise ValueError(f"Error compiling model: {error}")
         output_path = Path(input_path).with_suffix(".mlmodelc")
         Path(compiled_path).rename(output_path)
-        return output_path
+        return str(output_path)
 
     def _create_compute_plan(self):
         """Create a compute plan for the model."""


### PR DESCRIPTION
This line does not work with Path instances: https://github.com/FL33TW00D/coremlprofiler/blob/f07db867ee0d786f15d8f7526cc9f6b5111c1a42/coremlprofiler/prof.py#L73